### PR TITLE
#52 ヘッダーの集約と各pageの高さ修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,26 @@
 <script setup lang="ts">
 import { RouterView } from "vue-router";
+import HeaderAll from "@/components/HeaderAll.vue";
+import { ref, onMounted } from "vue";
+
+const headerRef = ref<InstanceType<typeof HeaderAll>>();
+const screenHeight = ref<number>(window.innerHeight);
+let headerHeightStyle = ref<string>();
+let pageHeightStyle = ref<string>();
+onMounted(() => {
+  const headerHeight = ref<number>(headerRef.value.$el.clientHeight);
+  const headerHeightVh = ref<number>(
+    (headerHeight.value / screenHeight.value) * 100
+  );
+  headerHeightStyle.value = headerHeightVh.value + "vh";
+  const pageHeightVh = ref<number>(100 - headerHeightVh.value);
+  pageHeightStyle.value = pageHeightVh.value + "vh";
+});
 </script>
 
 <template>
-  <RouterView />
+  <div>
+    <HeaderAll ref="headerRef" :style="{ height: headerHeightStyle }" />
+    <RouterView :style="{ height: pageHeightStyle }" />
+  </div>
 </template>

--- a/src/components/GamePage.vue
+++ b/src/components/GamePage.vue
@@ -232,8 +232,7 @@ document.onkeyup = (event) => {
 };
 </script>
 
-<template class="box">
-  <div>
+<template>
     <!-- 上半分のHTML -->
     <div
       ref="upper"
@@ -738,19 +737,15 @@ document.onkeyup = (event) => {
         </div>
       </div>
     </div>
-  </div>
   <WinDialog :showMyCodeDialog="showMyCodeDialog" @closeDialog="closeDialog" />
 </template>
 <style>
-.box {
-  height: 100vh;
-  width: 100%;
-}
 .mass {
   width: 100%;
 }
 .upperbox {
-  height: 45vh;
+  height: 45%;
+  margin: 0;
 }
 .codearea {
   width: 80%;
@@ -758,7 +753,7 @@ document.onkeyup = (event) => {
 }
 .bottombox {
   width: 100%;
-  height: 45.3vh;
+  height: 55%;
 }
 .boardarea {
   width: 978px;

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,50 +1,49 @@
-<script setup lang="ts">
-import HeaderAll from "@/components/HeaderAll.vue";
-</script>
+<script setup lang="ts"></script>
 
 <template>
-  <HeaderAll />
-  <!--背景が黄色の一番大本の箱-->
-  <div class="box sm:bg-yellow-500">
-    <!--welcome userと言語、レベルをいれるための箱。（ここは横並びのためflexboxの利用)-->
-    <!--サイズの調整のため透明な横幅60%の箱にいったん入れる-->
-    <div class="flex pt-10 justify-center items-center">
-      <div class="welcome-box flex px-10 py-10 items-center justify-around">
-        <div class="font-bold text-4xl">Welcome User!</div>
-        <!--言語とレベルが縦並びなのでさらに箱を一つ加える-->
-        <div>
-          <div class="text-2xl px-0">プログラミング言語: JavaScript</div>
-          <div class="text-2xl px-0">レベル: ２</div>
+  <div class="top">
+    <!--背景が黄色の一番大本の箱-->
+    <div class="box h-full sm:bg-yellow-500">
+      <!--welcome userと言語、レベルをいれるための箱。（ここは横並びのためflexboxの利用)-->
+      <!--サイズの調整のため透明な横幅60%の箱にいったん入れる-->
+      <div class="flex pt-10 justify-center items-center">
+        <div class="welcome-box flex px-10 py-10 items-center justify-around">
+          <div class="font-bold text-4xl">Welcome User!</div>
+          <!--言語とレベルが縦並びなのでさらに箱を一つ加える-->
+          <div>
+            <div class="text-2xl px-0">プログラミング言語: JavaScript</div>
+            <div class="text-2xl px-0">レベル: ２</div>
+          </div>
         </div>
       </div>
-    </div>
 
-    <!--ルール説明のための箱-->
-    <div class="justify-center mt-6 items-center flex">
-      <ol class="rule-box rounded-lg p-10 bg-gray-100 list-disc">
-        <span class="text-5xl">ルール</span>
-        <li class="text-2xl pt-5">任意のキーを押すと始まります</li>
-        <li class="text-2xl">
-          左側にソースコードが、右側に自分の書いているコードがでます
-        </li>
-        <li class="text-2xl">全てのコードを書き終えたら自動的に終了します</li>
-        <li class="text-2xl">レベルはコードを書く量により変わります</li>
-      </ol>
-    </div>
+      <!--ルール説明のための箱-->
+      <div class="justify-center mt-6 items-center flex">
+        <ol class="rule-box rounded-lg p-10 bg-gray-100 list-disc">
+          <span class="text-5xl">ルール</span>
+          <li class="text-2xl pt-5">任意のキーを押すと始まります</li>
+          <li class="text-2xl">
+            左側にソースコードが、右側に自分の書いているコードがでます
+          </li>
+          <li class="text-2xl">全てのコードを書き終えたら自動的に終了します</li>
+          <li class="text-2xl">レベルはコードを書く量により変わります</li>
+        </ol>
+      </div>
 
-    <!--「メインに戻る」と「スタート」のボタンを格納-->
-    <div class="pt-20 pb-20 flex items-center justify-center">
-      <div class="flex button-box justify-around">
-        <RouterLink
-          class="inline-block px-20 py-3 rounded-lg shadow-lg bg-indigo-700 text-white"
-          to="/"
-          >ホーム画面</RouterLink
-        >
-        <a
-          href="#"
-          class="inline-block px-20 py-3 rounded-lg shadow-lg bg-gray-600 text-white"
-          >スタート</a
-        >
+      <!--「メインに戻る」と「スタート」のボタンを格納-->
+      <div class="pt-10 flex items-center justify-center">
+        <div class="flex button-box justify-around">
+          <RouterLink
+            class="inline-block px-20 py-3 rounded-lg shadow-lg bg-indigo-700 text-white"
+            to="/"
+            >ホーム画面</RouterLink
+          >
+          <a
+            href="#"
+            class="inline-block px-20 py-3 rounded-lg shadow-lg bg-gray-600 text-white"
+            >スタート</a
+          >
+        </div>
       </div>
     </div>
   </div>
@@ -52,7 +51,6 @@ import HeaderAll from "@/components/HeaderAll.vue";
 
 <style>
 .box {
-  height: 92.2vh;
   width: 100%;
 }
 

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import HeaderAll from "@/components/HeaderAll.vue";
 import GamePage from "@/components/GamePage.vue";
 </script>
 
-<template class="box">
-  <HeaderAll />
-  <GamePage />
+<template>
+  <div class="top">
+    <GamePage />
+  </div>
 </template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,26 +1,16 @@
 <script setup lang="ts">
-import HeaderAll from "@/components/HeaderAll.vue";
 import HomeLeftContainer from "../components/HomeLeftContainer.vue";
 import HomeRightContainer from "../components/HomeRightContainer.vue";
-import { ref, onMounted } from "vue";
 import { userStore } from "../stores/user";
 import { storeToRefs } from "pinia";
 
 const user = userStore();
 const { name } = storeToRefs(user);
-const headerRef = ref<InstanceType<typeof HeaderAll>>();
-let homeHeightStyle = ref<string>();
-onMounted(() => {
-  const headerHeight = ref<number>(headerRef.value.$el.clientHeight);
-  const headerHeightVh = ref<number>((headerHeight.value * 100) / 1000);
-  homeHeightStyle.value = 100 - headerHeightVh.value + "vh";
-});
 </script>
 
 <template>
   <main>
-    <HeaderAll ref="headerRef" />
-    <div :style="{ height: homeHeightStyle }" class="h-[84.8vh] bg-yellow-300">
+    <div class="h-full bg-yellow-300">
       <div class="flex flex-col justify-center text-center h-1/2">
         <p>A website focused on improving your coding skills</p>
         <h2 class="text-5xl my-4">CODE-TYPING</h2>
@@ -48,9 +38,3 @@ onMounted(() => {
     </div>
   </main>
 </template>
-
-<style scoped>
-.home-height {
-  height: v-bind("headerHeight") px;
-}
-</style>

--- a/src/views/ResultView.vue
+++ b/src/views/ResultView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { RouterLink } from "vue-router";
-import HeaderAll from "@/components/HeaderAll.vue";
 import { timerStore } from "../stores/timer";
 import { storeToRefs } from "pinia";
 import { codeStore } from "../stores/code";
@@ -13,8 +12,6 @@ const { getMissCount } = storeToRefs(code);
 </script>
 
 <template>
-  <!-- ヘッダーの追加 -->
-  <HeaderAll />
   <!--背景が黄色の一番大本の箱-->
   <div class="box bg-yellow-500 pt-20">
     <!--スコアの箱-->
@@ -67,7 +64,6 @@ const { getMissCount } = storeToRefs(code);
 <style>
 .box {
   width: 100%;
-  height: 92.1vh;
   background-position: center;
 }
 .result-box {


### PR DESCRIPTION
## Issue
<!---
* Issue番号のURLを記載する
-->
#52 

## レビューしてもらいたい箇所
<!---
* レビューで主に何を見て欲しいか
-->
- 各viewファイルからheaderAllコンポーネントが消えているか
- 結果画面以外のページの画面の高さがスクロールできないように修正されているか
## やったこと
<!---
* 実装の技術的な内容を箇条書き
-->
- 各pageからのheaderAllコンポーネントの削除
- App.vueへの集約
- 画面高さ調整
## やらなかったこと
<!---
* TODO・保留したこと
* 別途対応するもの
* 後ほどリファクタリングしたい
* などあれば箇条書き
-->
結果画面は現在のレイアウトを作成してもらっているので、headerAllコンポーネントの削除のみを行いました。
- ヘッダーのタイマーの表示をゲーム画面のみの表示に修正しようとしましたが、うまくrouteからpathが取得できなかったため、別のissueで対応しようと思います。